### PR TITLE
Fixing overlap attemp

### DIFF
--- a/index.html
+++ b/index.html
@@ -130,7 +130,7 @@
     <!-- <DISPALY Tableau> -->
     <div class="info-map-chart">
       <div class="col-lg-5 col-md-5 col-sm-5">
-        <div class='tableauPlaceholder' id='viz1653668618938' style='position: relative'><noscript><a href='#'><img
+        <div class='tableauPlaceholder-info' id='viz1653668618938' style='position: relative'><noscript><a href='#'><img
                 alt='Happiness '
                 src='https:&#47;&#47;public.tableau.com&#47;static&#47;images&#47;2H&#47;2HFRRTG74&#47;1_rss.png'
                 style='border: none' /></a></noscript><object class='tableauViz' style='display:none;'>
@@ -146,7 +146,8 @@
             <param name='display_overlay' value='yes' />
             <param name='display_count' value='yes' />
             <param name='language' value='en-US' />
-          </object></div>
+          </object>
+        </div>
         <script
           type='text/javascript'>                    var divElement = document.getElementById('viz1653668618938'); var vizElement = divElement.getElementsByTagName('object')[0]; if (divElement.offsetWidth > 800) { vizElement.style.width = '1000px'; vizElement.style.height = '827px'; } else if (divElement.offsetWidth > 500) { vizElement.style.width = '1000px'; vizElement.style.height = '827px'; } else { vizElement.style.width = '100%'; vizElement.style.height = '1227px'; } var scriptElement = document.createElement('script'); scriptElement.src = 'https://public.tableau.com/javascripts/api/viz_v1.js'; vizElement.parentNode.insertBefore(scriptElement, vizElement);                </script>
       </div>
@@ -154,7 +155,7 @@
 
     <div class="regional-chart">
       <div class="col-lg-5 col-md-5 col-sm-5">
-        <div class='tableauPlaceholder' id='viz1653668849508' style='position: relative'><noscript><a href='#'><img
+        <div class='tableauPlaceholder-regional' id='viz1653668849508' style='position: relative'><noscript><a href='#'><img
                 alt='Happiness_distribution '
                 src='https:&#47;&#47;public.tableau.com&#47;static&#47;images&#47;ha&#47;happiness-region-distribution&#47;Happiness_distribution&#47;1_rss.png'
                 style='border: none' /></a></noscript><object class='tableauViz' style='display:none;'>

--- a/static/css/main_style.css
+++ b/static/css/main_style.css
@@ -76,13 +76,29 @@ body {
 
 }
 
-div.tableauPlaceholder  {
-    
-    overflow: scroll !important;
-    height: 100% !important;
-    width: 100%  !important;
+div.tableauPlaceholder-regional{
+
+    left: 10%;
+    display: inline-block;
+    height: auto !important;
+    width: 100%; max-width: 1000px;
     bottom: 15px;
-    margin: 0 auto;
+    margin: auto;
+    position: relative !important;
+}
+
+div.tableauPlaceholder-info  {
+    
+    overflow: auto;
+    right: 6%;
+    display: inline-flexbox;
+    height: auto !important;
+    width: 119% !important; 
+    max-width: 1000px !important;
+    bottom: 15px;
+    margin: auto;
+    position: relative !important;
+
 }
 
 
@@ -128,8 +144,10 @@ nav a{
 }
 
 nav a:hover{
-    color: #000;
+    color: #000 !important;
 }
+
+
 
 nav a::before{
     content: '';
@@ -150,7 +168,9 @@ nav a:hover::before{
     width: 100%;
 }
 
-
+nav a:visited{
+    color: lightgray;
+}
 
 
 


### PR DESCRIPTION
Attempt to fix overlap of  embed links.
May have to re-consider the use of embed links to limit use to one or one per row.
Prioritize making charts manually through plotly to ensure ease of use and client side dynamic scaling(in future)